### PR TITLE
Replace deprecated CoupledImplicitEuler with CoupledTimeDerivative

### DIFF
--- a/problems/CHLarrySplit.i
+++ b/problems/CHLarrySplit.i
@@ -61,7 +61,7 @@ active = 'SMP'
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/problems/CalphadNewElasNewDiff.i
+++ b/problems/CalphadNewElasNewDiff.i
@@ -186,7 +186,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/problems/CalphadNewElasOldDiff.i
+++ b/problems/CalphadNewElasOldDiff.i
@@ -186,7 +186,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/problems/CalphadNewElasOldDiff_recoverOldElas.i
+++ b/problems/CalphadNewElasOldDiff_recoverOldElas.i
@@ -186,7 +186,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/problems/CalphadOldElasNewDiff.i
+++ b/problems/CalphadOldElasNewDiff.i
@@ -186,7 +186,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/problems/CalphadOldElasOldDiff.i
+++ b/problems/CalphadOldElasOldDiff.i
@@ -187,7 +187,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/problems/CalphadSplitCoupled.i
+++ b/problems/CalphadSplitCoupled.i
@@ -167,7 +167,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/problems/CalphadSplitCoupled_scaled_SMP.i
+++ b/problems/CalphadSplitCoupled_scaled_SMP.i
@@ -163,7 +163,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/problems/CalphadSplitCoupled_scaled_SMP_SM.i
+++ b/problems/CalphadSplitCoupled_scaled_SMP_SM.i
@@ -191,7 +191,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/problems/Calphad_3OP.i
+++ b/problems/Calphad_3OP.i
@@ -150,7 +150,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = c
   [../]

--- a/problems/Calphad_CNG.i
+++ b/problems/Calphad_CNG.i
@@ -336,7 +336,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/problems/MeshSolutionModify_segfault.i
+++ b/problems/MeshSolutionModify_segfault.i
@@ -283,7 +283,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/problems/visualizeCalphadEnergy.i
+++ b/problems/visualizeCalphadEnergy.i
@@ -186,7 +186,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/tests/ZrHCalphad/ZrHCalphad.i
+++ b/tests/ZrHCalphad/ZrHCalphad.i
@@ -150,7 +150,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/tests/ZrHCalphad/ZrHCalphad_3OP.i
+++ b/tests/ZrHCalphad/ZrHCalphad_3OP.i
@@ -134,7 +134,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = c
   [../]

--- a/tests/energy_auxkernels_test/AuxBulkEnergyCalphad.i
+++ b/tests/energy_auxkernels_test/AuxBulkEnergyCalphad.i
@@ -103,7 +103,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/tests/energy_auxkernels_test/AuxCalphadElasticity.i
+++ b/tests/energy_auxkernels_test/AuxCalphadElasticity.i
@@ -109,7 +109,7 @@
   [../]
 
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/tests/energy_auxkernels_test/AuxElasticEnergy.i
+++ b/tests/energy_auxkernels_test/AuxElasticEnergy.i
@@ -116,7 +116,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/tests/energy_auxkernels_test/AuxGradientEnergy.i
+++ b/tests/energy_auxkernels_test/AuxGradientEnergy.i
@@ -114,7 +114,7 @@
 
 [Kernels]
   [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]

--- a/tests/nucleation_auxkernels_test/AuxCalphadEnergy.i
+++ b/tests/nucleation_auxkernels_test/AuxCalphadEnergy.i
@@ -103,7 +103,7 @@
 
 [Kernels]
     [./dcdt]
-    type = CoupledImplicitEuler
+    type = CoupledTimeDerivative
     variable = mu
     v = concentration
   [../]


### PR DESCRIPTION
I deprecated the name CoupledImplicitEuler a while ago and the deprecation date was reached today.
