### PR TITLE
Prepare Hyrax for coupledGradient() const reference return value.

### DIFF
--- a/include/auxkernels/AuxCanonicalEnsemble.h
+++ b/include/auxkernels/AuxCanonicalEnsemble.h
@@ -31,8 +31,8 @@ private:
   const VariableValue & _X;
   const VariableValue & _OP;
 
-  VariableGradient & _grad_X;
-  VariableGradient & _grad_OP;
+  const VariableGradient & _grad_X;
+  const VariableGradient & _grad_OP;
   
   const MaterialProperty<Real> & _molar_vol;
 

--- a/include/auxkernels/AuxGradientEnergy.h
+++ b/include/auxkernels/AuxGradientEnergy.h
@@ -28,11 +28,9 @@ protected:
 
 private:
 
-  VariableGradient & _grad_var;
+  const VariableGradient & _grad_var;
   std::string _kappa_name;
   const MaterialProperty<Real> & _kappa;
-
-
 };
 
 #endif //AUXGRADIENTENERGY_H

--- a/include/kernels/CHBulkCoupled.h
+++ b/include/kernels/CHBulkCoupled.h
@@ -44,7 +44,7 @@ protected:
   const MaterialProperty<Real> & _c1;  ///< position-ish of 1st energy well in c-space (terminal solid solubility)
 
   const VariableValue & _coupled_OP_var;  ///< Allen-Cahn equation variable (order parameter, probably)
-  VariableGradient & _coupled_OP_grad;  ///< gradient of AC variable
+  const VariableGradient & _coupled_OP_grad;  ///< gradient of AC variable
 };
 
 #endif //CHBULKCOUPLED_H

--- a/include/kernels/CHBulkPolyCoupled.h
+++ b/include/kernels/CHBulkPolyCoupled.h
@@ -43,7 +43,7 @@ private:
   unsigned int _n_OP_variables;
 
   std::vector<const VariableValue *>  _coupled_OP_variables;  ///< Allen-Cahn equation variable (order parameter, probably)
-  std::vector<VariableGradient *>  _coupled_OP_grads;  ///< gradient of AC variable
+  std::vector<const VariableGradient *>  _coupled_OP_grads;  ///< gradient of AC variable
 
 };
 

--- a/include/kernels/CHCoupledCalphad.h
+++ b/include/kernels/CHCoupledCalphad.h
@@ -54,7 +54,7 @@ private:
 
   unsigned int _n_OP_variables;
   std::vector<const VariableValue *> _OP;
-  std::vector<VariableGradient *> _grad_OP;
+  std::vector<const VariableGradient *> _grad_OP;
 
   Real _Heaviside;
   std::vector<Real> _dHeaviside;

--- a/include/kernels/CHCoupledSplit.h
+++ b/include/kernels/CHCoupledSplit.h
@@ -35,7 +35,7 @@ private:
   const MaterialProperty<Real> & _c1;  ///< position-ish of 1st energy well in c-space (terminal solid solubility)
 
   const VariableValue & _coupled_OP;  ///< Allen-Cahn equation variable (order parameter, probably)
-//  VariableGradient & _coupled_OP_grad;  ///< gradient of AC variable
+//  const VariableGradient & _coupled_OP_grad;  ///< gradient of AC variable
 };
 
 #endif //CHCOUPLEDSPLIT_H

--- a/include/materials/FreeEnergy.h
+++ b/include/materials/FreeEnergy.h
@@ -35,15 +35,13 @@ protected:
   //COUPLED VARIABLES
   const VariableValue & _c;   //coupled concentration
   const VariableValue & _n;   //coupled order parameter
-  VariableGradient & _grad_c;
-  VariableGradient & _grad_n;
+  const VariableGradient & _grad_c;
+  const VariableGradient & _grad_n;
 
   MaterialProperty<Real> & _free_energy_density;  //free energy functional energy density
 
   MaterialProperty<Real> & _alpha_energy_density; //free energy density of only the alpha phase
   MaterialProperty<Real> & _delta_energy_density; //free energy density of only the delta phase
-
-private:
 };
 
 #endif //FREEENERGY_H


### PR DESCRIPTION
This set of changes prepares Hyrax to work with an upcoming version of
MOOSE in which coupledGradient() returns a const reference.

Refs idaholab/moose#6327.
