### PR TITLE
libMesh::TypeVector::size() and size_sq() have been deprecated.

### DIFF
--- a/src/auxkernels/AuxCanonicalEnsemble.C
+++ b/src/auxkernels/AuxCanonicalEnsemble.C
@@ -60,8 +60,8 @@ AuxCanonicalEnsemble::computeValue()
   
   Real kappa_scale_factor = _length_scale_factor*_length_scale_factor*_energy_scale_factor;
   
-  Real fgrad = 0.5*_kappa_X[_qp]*kappa_scale_factor*_grad_X[_qp].size_sq()
-    + 0.5*_kappa_OP[_qp]*kappa_scale_factor*_grad_OP[_qp].size_sq();
+  Real fgrad = 0.5*_kappa_X[_qp]*kappa_scale_factor*_grad_X[_qp].norm_sq()
+    + 0.5*_kappa_OP[_qp]*kappa_scale_factor*_grad_OP[_qp].norm_sq();
 
   Real mu_c = ((1 - H)*_dGalpha_dc[_qp] + H*_dGdelta_dc[_qp])/_molar_vol[_qp];
   

--- a/src/auxkernels/AuxGradientEnergy.C
+++ b/src/auxkernels/AuxGradientEnergy.C
@@ -31,7 +31,7 @@ AuxGradientEnergy::AuxGradientEnergy(const InputParameters & parameters) :
 Real
 AuxGradientEnergy::computeValue()
 {
- return 0.5*_kappa[_qp]*_grad_var[_qp].size_sq();
+ return 0.5*_kappa[_qp]*_grad_var[_qp].norm_sq();
 }
 
 

--- a/src/materials/FreeEnergy.C
+++ b/src/materials/FreeEnergy.C
@@ -58,8 +58,8 @@ FreeEnergy::computeQpProperties()
   Real fchem = (1 - Heaviside)*_alpha_energy[_qp] + Heaviside*_delta_energy[_qp] + _W[_qp]*g;
 
   //this puts kappas as J/m
-  Real grad_c_term = 0.5*grad_scale_factor*_kappa_c[_qp]*_grad_c[_qp].size_sq();
-  Real grad_n_term = 0.5*grad_scale_factor*_kappa_n[_qp]*_grad_n[_qp].size_sq();
+  Real grad_c_term = 0.5*grad_scale_factor*_kappa_c[_qp]*_grad_c[_qp].norm_sq();
+  Real grad_n_term = 0.5*grad_scale_factor*_kappa_n[_qp]*_grad_n[_qp].norm_sq();
 
   //convert energy to J/nm^3 and J/nm
   grad_c_term *= _length_scale;


### PR DESCRIPTION
They are replaced by norm() and norm_sq(), respectively.

Refs libMesh/libmesh#829.
