### PR TITLE
DataIO and UserObjectWarehouse fixes

### DIFF
--- a/include/userobjects/Nucleus.h
+++ b/include/userobjects/Nucleus.h
@@ -15,6 +15,7 @@
 #define NUCLEUS_H
 
 #include "Moose.h"
+#include "DataIO.h"
 
 #include "libmesh/libmesh.h"
 #include "libmesh/elem.h"
@@ -23,59 +24,51 @@
 class Nucleus
 {
 public:
-
   /**
    * Default constructor, everything initialized to zero
    */
   Nucleus();
 
-  /**
-   * Copy constructor
-   */
-  Nucleus(const Nucleus &a);
-
-  Nucleus & operator= (const Nucleus &a);
-
-  ~Nucleus() {}
-
   Point getLocation() const;
-
   Real getStartTime() const;
-
   Real getEndTime() const;
-
   int getOrientation() const;
 
   void setLocation(Point a);
-
   void setStartTime(Real a);
-
   void setEndTime(Real a);
-
   void setOrientation(int a);
 
+  // TODO: these should be deprecated in favor of the built-in dataLoad/dataStore stuff and packed range communication
   static void pack(const std::vector<Nucleus> &, std::vector<Real> &);
   static void unpack(const std::vector<Real> &, std::vector<Nucleus> &);
 
-/**
- * the size of the Nucleus object for packing and unpacking (3 for location, 1 each for
- * start time, end time, orientation
- */
-static unsigned int stride() { return _stride; }
-
-protected:
+  /**
+   * the size of the Nucleus object for packing and unpacking (3 for location, 1 each for
+   * start time, end time, orientation
+   */
+  static unsigned int stride() { return _stride; }
 
 private:
-
   Point _location; //holds the central location of the nucleus
   Real _start_time; //when this nucleus came into existence
   Real _end_time; // when the nucleation event ends - NOT necessarily the lifetime of the nucleus
   int _orientation; // the orientation of the particle
 
-
   //stride length: x, y, z, start, end, orientation
   static const unsigned int _stride = 6;
 
+  template<class T>
+  friend void dataStore(std::ostream &, T &, void *);
+
+  template<class T>
+  friend void dataLoad(std::istream &, T &, void *);
 };
+
+template<>
+void dataStore(std::ostream &, Nucleus &, void *);
+
+template<>
+void dataLoad(std::istream &, Nucleus &, void *);
 
 #endif //NUCLEUS_H

--- a/src/executioners/MeshSolutionModify.C
+++ b/src/executioners/MeshSolutionModify.C
@@ -80,7 +80,7 @@ MeshSolutionModify::endStep(Real input_time)
 }
 #endif
     }
-    _problem.computeUserObjects(EXEC_CUSTOM, UserObjectWarehouse::ALL);
+    _problem.computeUserObjects(EXEC_CUSTOM, Moose::AuxGroup::ALL);
 
     // indicate a forced output if at a sync point
     if (_at_sync_point)

--- a/src/userobjects/Nucleus.C
+++ b/src/userobjects/Nucleus.C
@@ -21,22 +21,6 @@ Nucleus::Nucleus():
   _location.zero();
 }
 
-Nucleus::Nucleus(const Nucleus &a)
-{
-  *this = a;
-}
-
-Nucleus &
-Nucleus::operator= (const Nucleus &a)
-{
-  _location = a._location;
-  _start_time = a._start_time;
-  _end_time = a._end_time;
-  _orientation = a._orientation;
-
-  return *this;
-}
-
 Point
 Nucleus::getLocation() const
 {
@@ -147,4 +131,22 @@ Nucleus::unpack(const std::vector<Real> & packed_data, std::vector<Nucleus> & un
   //might want to include some error message in here in case unpacking screws up
 }
 
+template<>
+void
+dataStore(std::ostream & stream, Nucleus & n, void * context)
+{
+  dataStore(stream, n._location, context);
+  dataStore(stream, n._start_time, context);
+  dataStore(stream, n._end_time, context);
+  dataStore(stream, n._orientation, context);
+}
 
+template<>
+void
+dataLoad(std::istream & stream, Nucleus & n, void * context)
+{
+  dataLoad(stream, n._location, context);
+  dataLoad(stream, n._start_time, context);
+  dataLoad(stream, n._end_time, context);
+  dataLoad(stream, n._orientation, context);
+}


### PR DESCRIPTION
https://github.com/idaholab/moose/pull/6495 introduces stricter compile time checking on types using the default data serialization. This fixes Hyrax to comply. I also threw in a small fix for a renamed enum (fallout from a warehouse rewrite).
