### PR TITLE
Replace ElasticityTensorR4

### DIFF
--- a/include/auxkernels/AuxCalphadElasticity.h
+++ b/include/auxkernels/AuxCalphadElasticity.h
@@ -13,7 +13,7 @@
 
 #include "AuxKernel.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 
 #include "CalphadAB1CD1.h"
 #include "CalphadAB1CD2.h"

--- a/include/auxkernels/AuxCalphadEnergy.h
+++ b/include/auxkernels/AuxCalphadEnergy.h
@@ -13,7 +13,7 @@
 
 #include "AuxKernel.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 
 #include "CalphadAB1CD1.h"
 #include "CalphadAB1CD2.h"
@@ -58,9 +58,9 @@ protected:
   const MaterialProperty<RankTwoTensor> & _elastic_strain;
   const MaterialProperty<RankTwoTensor> & _local_strain;
 
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
-  const MaterialProperty<ElasticityTensorR4> & _Cijkl_MP;  //matrix
-  const MaterialProperty<ElasticityTensorR4> & _Cijkl_precipitate_MP; //precipitate
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _Cijkl_MP;  //matrix
+  const MaterialProperty<RankFourTensor> & _Cijkl_precipitate_MP; //precipitate
 
 
   const MaterialProperty<std::vector<RankTwoTensor> > & _precipitate_eigenstrain;

--- a/include/auxkernels/AuxChemElastic.h
+++ b/include/auxkernels/AuxChemElastic.h
@@ -13,7 +13,7 @@
 
 #include "AuxKernel.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 
 //forward declaration
 class AuxChemElastic;
@@ -61,10 +61,10 @@ protected:
   unsigned int _noncons_var_num;
 
   const MaterialProperty<std::vector<RankTwoTensor> > & _eigenstrains_rotated_MP;
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
 
   const MaterialProperty<std::vector<RankTwoTensor> > & _precipitate_eigenstrain_rotated;
-  const MaterialProperty<ElasticityTensorR4> & _precipitate_elasticity;
+  const MaterialProperty<RankFourTensor> & _precipitate_elasticity;
 
   const MaterialProperty<RankTwoTensor> & _local_strain;
 

--- a/include/auxkernels/AuxDFelDC.h
+++ b/include/auxkernels/AuxDFelDC.h
@@ -12,7 +12,7 @@
 #define AUXDFELDC_H
 
 #include "AuxKernel.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RankTwoTensor.h"
 
 class AuxDFelDC;
@@ -30,7 +30,7 @@ protected:
 
 private:
 
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
   const MaterialProperty<RankTwoTensor> & _elastic_strain;
   const MaterialProperty<RankTwoTensor> & _dc_misfit_strain;
 

--- a/include/auxkernels/AuxElasticEnergy.h
+++ b/include/auxkernels/AuxElasticEnergy.h
@@ -12,7 +12,7 @@
 #define AUXELASTICENERGY_H
 
 #include "AuxKernel.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RankTwoTensor.h"
 
 class AuxElasticEnergy;
@@ -30,7 +30,7 @@ protected:
 
 private:
 
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
   const MaterialProperty<RankTwoTensor> & _elastic_strain;
 
 //Real _scaling_factor;

--- a/include/auxkernels/AuxElasticInteractionEnergy.h
+++ b/include/auxkernels/AuxElasticInteractionEnergy.h
@@ -12,7 +12,7 @@
 #define AUXELASTICINTERACTIONENERGY_H
 
 #include "AuxKernel.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RankTwoTensor.h"
 
 class AuxElasticInteractionEnergy;

--- a/include/auxkernels/AuxGuoEnergy.h
+++ b/include/auxkernels/AuxGuoEnergy.h
@@ -13,7 +13,7 @@
 
 #include "AuxChemElastic.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 
 //forward declaration
 class AuxGuoEnergy;
@@ -58,10 +58,10 @@ protected:
   unsigned int _noncons_var_num;
 
   const MaterialProperty<std::vector<RankTwoTensor> > & _eigenstrains_rotated_MP;
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
 
   const MaterialProperty<std::vector<RankTwoTensor> > & _precipitate_eigenstrain_rotated;
-  const MaterialProperty<ElasticityTensorR4> & _precipitate_elasticity;
+  const MaterialProperty<RankFourTensor> & _precipitate_elasticity;
 
   const MaterialProperty<RankTwoTensor> & _local_strain;
 

--- a/include/bcs/StressBC.h
+++ b/include/bcs/StressBC.h
@@ -16,7 +16,7 @@
 
 #include "IntegratedBC.h"
 #include "RankTwoTensor.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 
 //LibMesh includes
 //#include "libmesh/vector_value.h"
@@ -46,7 +46,7 @@ protected:
   RankTwoTensor _boundary_stress;
   std::vector<const VariableValue *> _boundary_stress_vars;
 
-  const MaterialProperty<ElasticityTensorR4> & _Jacobian_mult;
+  const MaterialProperty<RankFourTensor> & _Jacobian_mult;
 
 
   const int _component;

--- a/include/kernels/ACPrecipMatrixElasticity.h
+++ b/include/kernels/ACPrecipMatrixElasticity.h
@@ -12,7 +12,7 @@
 #define ACPRECIPMATRIXELASTICITY_H
 
 #include "ACBulk.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RankTwoTensor.h"
 
 class ACPrecipMatrixElasticity;
@@ -35,9 +35,9 @@ protected:
   virtual Real computeDFDOP(PFFunctionType type);
 
   // system elasticity tensor, varies in space
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
-  const MaterialProperty<std::vector<ElasticityTensorR4> > & _dn_elasticity_tensor;
-  const MaterialProperty<std::vector<ElasticityTensorR4> > & _dndn_elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
+  const MaterialProperty<std::vector<RankFourTensor> > & _dn_elasticity_tensor;
+  const MaterialProperty<std::vector<RankFourTensor> > & _dndn_elasticity_tensor;
 
   const MaterialProperty<RankTwoTensor> & _elastic_strain;
   const MaterialProperty<std::vector<RankTwoTensor> > & _dn_misfit_strain;

--- a/include/kernels/ACTransformElasticDF.h
+++ b/include/kernels/ACTransformElasticDF.h
@@ -13,7 +13,7 @@
 
 #include "ACBulk.h"
 
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RankTwoTensor.h"
 
 #include <string>
@@ -58,7 +58,7 @@ protected:
   //virtual Real calculateSecondJacobianTerm();
 
   // system elasticity tensor, varies in space
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
   const MaterialProperty<std::vector<RankTwoTensor > > & _eigenstrains_rotated_MP;
   const MaterialProperty<RankTwoTensor> & _local_strain;
 

--- a/include/kernels/CHPrecipMatrixElasticity.h
+++ b/include/kernels/CHPrecipMatrixElasticity.h
@@ -12,7 +12,7 @@
 #define CHPRECIPMATRIXELASTICITY_H
 
 #include "SplitCHCRes.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RankTwoTensor.h"
 
 class CHPrecipMatrixElasticity;
@@ -32,8 +32,8 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   // system elasticity tensor, varies in space
-  const MaterialProperty<ElasticityTensorR4> & _elasticity_tensor;
-  const MaterialProperty<std::vector<ElasticityTensorR4> > & _dn_elasticity_tensor;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor;
+  const MaterialProperty<std::vector<RankFourTensor> > & _dn_elasticity_tensor;
 
   const MaterialProperty<RankTwoTensor> & _elastic_strain;
   const MaterialProperty<RankTwoTensor> & _dc_misfit_strain;

--- a/include/materials/LinearSingleCrystalPrecipitateMaterial.h
+++ b/include/materials/LinearSingleCrystalPrecipitateMaterial.h
@@ -14,7 +14,7 @@
 
 //#include "LinearElasticMaterial.h"
 #include "TensorMechanicsMaterial.h"
-#include "ElasticityTensorR4.h"
+#include "RankFourTensor.h"
 #include "RankTwoTensor.h"
 
 /**
@@ -69,7 +69,7 @@ protected:
   Real _scaling_factor;
 
   // Individual material information.  Don't touch these once they're initialized!
-  ElasticityTensorR4 _Cijkl_precipitate;
+  RankFourTensor _Cijkl_precipitate;
   RankTwoTensor _eigenstrain;
 
   const VariableValue & _T;
@@ -84,8 +84,8 @@ protected:
   MaterialProperty<RankTwoTensor> & _local_strain; //total strain
   MaterialProperty<RankTwoTensor> & _misfit_strain; //sum of all the active eigenstrains in space
   MaterialProperty<std::vector<RankTwoTensor> > & _eigenstrains_MP; //whether each variant is active or not in space
-  MaterialProperty<ElasticityTensorR4> & _Cijkl_MP; //holds the matrix Cijkl everywhere
-  MaterialProperty<ElasticityTensorR4> & _Cijkl_precipitates_MP; //holds the precipitates Cijkl everywhere
+  MaterialProperty<RankFourTensor> & _Cijkl_MP; //holds the matrix Cijkl everywhere
+  MaterialProperty<RankFourTensor> & _Cijkl_precipitates_MP; //holds the precipitates Cijkl everywhere
 
   // derivatives of the misfit strain with respect to order parameter
   MaterialProperty<std::vector<RankTwoTensor> > & _d_eigenstrains_MP;

--- a/include/materials/PrecipitateMatrixMisfitMaterial.h
+++ b/include/materials/PrecipitateMatrixMisfitMaterial.h
@@ -51,11 +51,11 @@ protected:
 
   MaterialProperty<RankTwoTensor> & _matrix_eigenstrain;  //lambda_ijkl*%factor as material property
 
-  MaterialProperty<std::vector<ElasticityTensorR4> > & _dn_elasticity_tensor;
-  MaterialProperty<ElasticityTensorR4> & _dc_elasticity_tensor;
-  MaterialProperty<std::vector<ElasticityTensorR4> > & _dndn_elasticity_tensor;
-  MaterialProperty<ElasticityTensorR4> & _dcdc_elasticity_tensor;
-  MaterialProperty<std::vector<ElasticityTensorR4> > & _dcdn_elasticity_tensor;
+  MaterialProperty<std::vector<RankFourTensor> > & _dn_elasticity_tensor;
+  MaterialProperty<RankFourTensor> & _dc_elasticity_tensor;
+  MaterialProperty<std::vector<RankFourTensor> > & _dndn_elasticity_tensor;
+  MaterialProperty<RankFourTensor> & _dcdc_elasticity_tensor;
+  MaterialProperty<std::vector<RankFourTensor> > & _dcdn_elasticity_tensor;
 
   MaterialProperty<std::vector<RankTwoTensor> > & _dn_misfit_strain;
   MaterialProperty<RankTwoTensor> & _dc_misfit_strain;

--- a/src/auxkernels/AuxCalphadEnergy.C
+++ b/src/auxkernels/AuxCalphadEnergy.C
@@ -46,9 +46,9 @@ AuxCalphadEnergy::AuxCalphadEnergy(const InputParameters & parameters) :
     _elastic_strain(getMaterialProperty<RankTwoTensor>("elastic_strain")),
     _local_strain(getMaterialProperty<RankTwoTensor>("local_strain")),
 
-    _elasticity_tensor(getMaterialProperty<ElasticityTensorR4>("elasticity_tensor")),
-    _Cijkl_MP(getMaterialProperty<ElasticityTensorR4>("Cijkl_MP")),
-    _Cijkl_precipitate_MP(getMaterialProperty<ElasticityTensorR4>("Cijkl_precipitates_MP")),
+    _elasticity_tensor(getMaterialProperty<RankFourTensor>("elasticity_tensor")),
+    _Cijkl_MP(getMaterialProperty<RankFourTensor>("Cijkl_MP")),
+    _Cijkl_precipitate_MP(getMaterialProperty<RankFourTensor>("Cijkl_precipitates_MP")),
 
     _precipitate_eigenstrain(getMaterialProperty<std::vector<RankTwoTensor> >("precipitate_eigenstrain")),
     _matrix_eigenstrain(getMaterialProperty<RankTwoTensor>("matrix_eigenstrain")),
@@ -156,7 +156,7 @@ AuxCalphadEnergy::computeDifferential()
 
   // _console<<"dfel_dX = "<<dfel_dX<<std::endl;
 
-  ElasticityTensorR4 dCijkl = (_Cijkl_precipitate_MP[_qp] - _Cijkl_MP[_qp])*(-1*_dH_dOP);
+  RankFourTensor dCijkl = (_Cijkl_precipitate_MP[_qp] - _Cijkl_MP[_qp])*(-1*_dH_dOP);
   b = _Cijkl_MP[_qp]*( (_dn_misfit_strain[_qp])[_OP_number-1]) *(-1);
   RankTwoTensor c = dCijkl*_elastic_strain[_qp];
 

--- a/src/auxkernels/AuxChemElastic.C
+++ b/src/auxkernels/AuxChemElastic.C
@@ -38,9 +38,9 @@ AuxChemElastic::AuxChemElastic(const InputParameters & parameters) :
     _c2(getMaterialProperty<Real>("C2")), */
     _noncons_var_num(getParam<int>("nonconserved_var_number")),
     _eigenstrains_rotated_MP(getMaterialProperty<std::vector<RankTwoTensor> >("eigenstrains_MP")),
-    _elasticity_tensor(getMaterialProperty<ElasticityTensorR4>("elasticity_tensor")),
+    _elasticity_tensor(getMaterialProperty<RankFourTensor>("elasticity_tensor")),
     _precipitate_eigenstrain_rotated(getMaterialProperty<std::vector<RankTwoTensor> >("precipitate_eigenstrain")),
-    _precipitate_elasticity(getMaterialProperty<ElasticityTensorR4>("Cijkl_precipitates_MP")),
+    _precipitate_elasticity(getMaterialProperty<RankFourTensor>("Cijkl_precipitates_MP")),
     _local_strain(getMaterialProperty<RankTwoTensor>("local_strain")),
     _d_eigenstrains_rotated_MP(getMaterialProperty<std::vector<RankTwoTensor> >("d_eigenstrains_MP"))
 {
@@ -121,7 +121,7 @@ AuxChemElastic::computeSelfElasticEnergy(bool matrix)
 {
   RankTwoTensor eigenstrain;
   RankTwoTensor c;
-  ElasticityTensorR4 elasticity;
+  RankFourTensor elasticity;
 
   if(matrix)
   {
@@ -144,7 +144,7 @@ AuxChemElastic::computeInteractionElasticEnergy(bool matrix)
 {
   RankTwoTensor eigenstrain;
   RankTwoTensor c;
-  ElasticityTensorR4 elasticity;
+  RankFourTensor elasticity;
 
   if(matrix)
   {
@@ -194,7 +194,7 @@ AuxChemElastic::computeDselfDnoncons()
   RankTwoTensor eigenstrain;
   RankTwoTensor d_eigenstrain;
   RankTwoTensor c;
-  ElasticityTensorR4 elasticity;
+  RankFourTensor elasticity;
 
   eigenstrain = (_eigenstrains_rotated_MP[_qp])[_noncons_var_num-1];
   d_eigenstrain =( _d_eigenstrains_rotated_MP[_qp])[_noncons_var_num-1];
@@ -210,7 +210,7 @@ AuxChemElastic::computeDintDnoncons()
 {
   RankTwoTensor d_eigenstrain;
   RankTwoTensor c;
-  ElasticityTensorR4 elasticity;
+  RankFourTensor elasticity;
 
   d_eigenstrain = (_precipitate_eigenstrain_rotated[_qp])[_noncons_var_num-1];
   elasticity = _precipitate_elasticity[_qp];

--- a/src/auxkernels/AuxDFelDC.C
+++ b/src/auxkernels/AuxDFelDC.C
@@ -23,7 +23,7 @@ InputParameters validParams<AuxDFelDC>()
 
 AuxDFelDC::AuxDFelDC(const InputParameters & parameters) :
     AuxKernel(parameters),
-    _elasticity_tensor(getMaterialProperty<ElasticityTensorR4>("elasticity_tensor")),
+    _elasticity_tensor(getMaterialProperty<RankFourTensor>("elasticity_tensor")),
     _elastic_strain(getMaterialProperty<RankTwoTensor>("elastic_strain")),
     _dc_misfit_strain(getMaterialProperty<RankTwoTensor>("dc_misfit_strain"))//,
     //_scaling_factor(getParam<Real>("scaling_factor"))

--- a/src/auxkernels/AuxElasticEnergy.C
+++ b/src/auxkernels/AuxElasticEnergy.C
@@ -23,7 +23,7 @@ InputParameters validParams<AuxElasticEnergy>()
 
 AuxElasticEnergy::AuxElasticEnergy(const InputParameters & parameters) :
     AuxKernel(parameters),
-    _elasticity_tensor(getMaterialProperty<ElasticityTensorR4>("elasticity_tensor")),
+    _elasticity_tensor(getMaterialProperty<RankFourTensor>("elasticity_tensor")),
     _elastic_strain(getMaterialProperty<RankTwoTensor>("elastic_strain"))//,
     //_scaling_factor(getParam<Real>("scaling_factor"))
 {

--- a/src/auxkernels/AuxGuoEnergy.C
+++ b/src/auxkernels/AuxGuoEnergy.C
@@ -43,9 +43,9 @@ AuxGuoEnergy::AuxGuoEnergy(const InputParameters & parameters) :
 /*
     _noncons_var_num(getParam<int>("nonconserved_var_number")),
     _eigenstrains_rotated_MP(getMaterialProperty<std::vector<RankTwoTensor> >("eigenstrains_MP")),
-    _elasticity_tensor(getMaterialProperty<ElasticityTensorR4>("elasticity_tensor")),
+    _elasticity_tensor(getMaterialProperty<RankFourTensor>("elasticity_tensor")),
     _precipitate_eigenstrain_rotated(getMaterialProperty<std::vector<RankTwoTensor> >("precipitate_eigenstrain")),
-    _precipitate_elasticity(getMaterialProperty<ElasticityTensorR4>("Cijkl_precipitates_MP")),
+    _precipitate_elasticity(getMaterialProperty<RankFourTensor>("Cijkl_precipitates_MP")),
     _local_strain(getMaterialProperty<RankTwoTensor>("local_strain")),
     _d_eigenstrains_rotated_MP(getMaterialProperty<std::vector<RankTwoTensor> >("d_eigenstrains_MP"))
 */
@@ -145,7 +145,7 @@ AuxGuoEnergy::computeSelfElasticEnergy(bool matrix)
 {
   RankTwoTensor eigenstrain;
   RankTwoTensor c;
-  ElasticityTensorR4 elasticity;
+  RankFourTensor elasticity;
 
   if(matrix)
   {
@@ -170,7 +170,7 @@ AuxGuoEnergy::computeInteractionElasticEnergy(bool matrix)
 {
   RankTwoTensor eigenstrain;
   RankTwoTensor c;
-  ElasticityTensorR4 elasticity;
+  RankFourTensor elasticity;
 
   if(matrix)
   {
@@ -238,7 +238,7 @@ AuxGuoEnergy::computeDselfDnoncons()
   RankTwoTensor eigenstrain;
   RankTwoTensor d_eigenstrain;
   RankTwoTensor c;
-  ElasticityTensorR4 elasticity;
+  RankFourTensor elasticity;
 
   eigenstrain = (_eigenstrains_rotated_MP[_qp])[_noncons_var_num-1];
   d_eigenstrain =( _d_eigenstrains_rotated_MP[_qp])[_noncons_var_num-1];
@@ -256,7 +256,7 @@ AuxGuoEnergy::computeDintDnoncons()
 {
   RankTwoTensor d_eigenstrain;
   RankTwoTensor c;
-  ElasticityTensorR4 elasticity;
+  RankFourTensor elasticity;
 
   d_eigenstrain = (_precipitate_eigenstrain_rotated[_qp])[_noncons_var_num-1];
   elasticity = _precipitate_elasticity[_qp];

--- a/src/bcs/StressBC.C
+++ b/src/bcs/StressBC.C
@@ -30,7 +30,7 @@ InputParameters validParams<StressBC>()
 StressBC::StressBC(const InputParameters & parameters) :
     IntegratedBC(parameters),
     _stress_vector(getParam<std::vector<Real> >("boundary_stress")),
-    _Jacobian_mult(getMaterialProperty<ElasticityTensorR4>("Jacobian_mult")),
+    _Jacobian_mult(getMaterialProperty<RankFourTensor>("Jacobian_mult")),
     _component(getParam<int>("component")),
     _convert_to_gpa(getParam<bool>("convert_to_gpa")),
     _multiplier(1)

--- a/src/kernels/ACPrecipMatrixElasticity.C
+++ b/src/kernels/ACPrecipMatrixElasticity.C
@@ -22,9 +22,9 @@ InputParameters validParams<ACPrecipMatrixElasticity>()
 
 ACPrecipMatrixElasticity::ACPrecipMatrixElasticity(const InputParameters & parameters) :
     ACBulk<Real>(parameters),
-    _elasticity_tensor(getMaterialProperty<ElasticityTensorR4>("elasticity_tensor")),
-    _dn_elasticity_tensor(getMaterialProperty<std::vector<ElasticityTensorR4> >("dn_elasticity_tensor")),
-    _dndn_elasticity_tensor(getMaterialProperty<std::vector<ElasticityTensorR4> >("dndn_elasticity_tensor")),
+    _elasticity_tensor(getMaterialProperty<RankFourTensor>("elasticity_tensor")),
+    _dn_elasticity_tensor(getMaterialProperty<std::vector<RankFourTensor> >("dn_elasticity_tensor")),
+    _dndn_elasticity_tensor(getMaterialProperty<std::vector<RankFourTensor> >("dndn_elasticity_tensor")),
     _elastic_strain(getMaterialProperty<RankTwoTensor>("elastic_strain")),
     _dn_misfit_strain(getMaterialProperty<std::vector<RankTwoTensor> >("dn_misfit_strain")),
     _dndn_misfit_strain(getMaterialProperty<std::vector<RankTwoTensor> >("dndn_misfit_strain")),

--- a/src/kernels/ACTransformElasticDF.C
+++ b/src/kernels/ACTransformElasticDF.C
@@ -32,7 +32,7 @@ InputParameters validParams<ACTransformElasticDF>()
 
 ACTransformElasticDF::ACTransformElasticDF(const InputParameters & parameters) :
     ACBulk<Real>(parameters),
-    _elasticity_tensor(getMaterialProperty<ElasticityTensorR4>("elasticity_tensor")),
+    _elasticity_tensor(getMaterialProperty<RankFourTensor>("elasticity_tensor")),
     _eigenstrains_rotated_MP(getMaterialProperty<std::vector<RankTwoTensor> >("eigenstrains_MP")),
     _local_strain(getMaterialProperty<RankTwoTensor>("local_strain")),
     _elastic_strain(getMaterialProperty<RankTwoTensor>("elastic_strain")),

--- a/src/kernels/CHPrecipMatrixElasticity.C
+++ b/src/kernels/CHPrecipMatrixElasticity.C
@@ -28,8 +28,8 @@ InputParameters validParams<CHPrecipMatrixElasticity>()
 
 CHPrecipMatrixElasticity::CHPrecipMatrixElasticity(const InputParameters & parameters)
     : SplitCHCRes(parameters),
-      _elasticity_tensor(getMaterialProperty<ElasticityTensorR4>("elasticity_tensor")),
-      _dn_elasticity_tensor(getMaterialProperty<std::vector<ElasticityTensorR4> >("dn_elasticity_tensor")),
+      _elasticity_tensor(getMaterialProperty<RankFourTensor>("elasticity_tensor")),
+      _dn_elasticity_tensor(getMaterialProperty<std::vector<RankFourTensor> >("dn_elasticity_tensor")),
       _elastic_strain(getMaterialProperty<RankTwoTensor>("elastic_strain")),
       _dc_misfit_strain(getMaterialProperty<RankTwoTensor>("dc_misfit_strain")),
       _dn_misfit_strain(getMaterialProperty<std::vector<RankTwoTensor> >("dn_misfit_strain")),

--- a/src/materials/LinearSingleCrystalPrecipitateMaterial.C
+++ b/src/materials/LinearSingleCrystalPrecipitateMaterial.C
@@ -59,8 +59,8 @@ LinearSingleCrystalPrecipitateMaterial::LinearSingleCrystalPrecipitateMaterial(c
     _misfit_strain(declareProperty<RankTwoTensor >("misfit_strain")),
 
     _eigenstrains_MP(declareProperty<std::vector<RankTwoTensor> >("eigenstrains_MP")),
-    _Cijkl_MP(declareProperty<ElasticityTensorR4>("Cijkl_MP")),
-    _Cijkl_precipitates_MP(declareProperty<ElasticityTensorR4>("Cijkl_precipitates_MP")),
+    _Cijkl_MP(declareProperty<RankFourTensor>("Cijkl_MP")),
+    _Cijkl_precipitates_MP(declareProperty<RankFourTensor>("Cijkl_precipitates_MP")),
     _d_eigenstrains_MP(declareProperty<std::vector<RankTwoTensor> >("d_eigenstrains_MP")),
     _precipitate_eigenstrain(declareProperty<std::vector<RankTwoTensor> >("precipitate_eigenstrain")),
     _misfit_T_coeffs_vector(getParam<std::vector<Real> >("misfit_temperature_coeffs")),

--- a/src/materials/PrecipitateMatrixMisfitMaterial.C
+++ b/src/materials/PrecipitateMatrixMisfitMaterial.C
@@ -45,11 +45,11 @@ PrecipitateMatrixMisfitMaterial::PrecipitateMatrixMisfitMaterial(const InputPara
     _dc_eigenstrain_matrix_MP(declareProperty<RankTwoTensor>("dc_eigenstrain_matrix_MP")),
     _matrix_eigenstrain(declareProperty<RankTwoTensor>("matrix_eigenstrain")),
 
-    _dn_elasticity_tensor(declareProperty<std::vector<ElasticityTensorR4> >("dn_elasticity_tensor")),
-    _dc_elasticity_tensor(declareProperty<ElasticityTensorR4>("dc_elasticity_tensor")),
-    _dndn_elasticity_tensor(declareProperty<std::vector<ElasticityTensorR4> >("dndn_elasticity_tensor")),
-    _dcdc_elasticity_tensor(declareProperty<ElasticityTensorR4>("dcdc_elasticity_tensor")),
-    _dcdn_elasticity_tensor(declareProperty<std::vector<ElasticityTensorR4> >("dcdn_elasticity_tensor")),
+    _dn_elasticity_tensor(declareProperty<std::vector<RankFourTensor> >("dn_elasticity_tensor")),
+    _dc_elasticity_tensor(declareProperty<RankFourTensor>("dc_elasticity_tensor")),
+    _dndn_elasticity_tensor(declareProperty<std::vector<RankFourTensor> >("dndn_elasticity_tensor")),
+    _dcdc_elasticity_tensor(declareProperty<RankFourTensor>("dcdc_elasticity_tensor")),
+    _dcdn_elasticity_tensor(declareProperty<std::vector<RankFourTensor> >("dcdn_elasticity_tensor")),
 
     _dn_misfit_strain(declareProperty<std::vector<RankTwoTensor> >("dn_misfit_strain")),
     _dc_misfit_strain(declareProperty<RankTwoTensor>("dc_misfit_strain")),
@@ -102,7 +102,7 @@ PrecipitateMatrixMisfitMaterial::computeQpElasticityTensor()
   //going to need to put temperature dependence in here
 
   Real inverse = 1/_scaling_factor;
-  ElasticityTensorR4 zeros;
+  RankFourTensor zeros;
   zeros.zero();
 
   //scale these so everything is scaled


### PR DESCRIPTION
Looks like all that was needed to fix Hyrax was replacing ElasticityTensorR$ (deprecated) with RankFourTensor.

Closes #14
