### PR TITLE
TensorMechanics fix

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,8 @@
 Andrea Jokisaari <anmida@umich.edu>
 Andrea Jokisaari <a.m.dangelewicz@gmail.com>
+Andrea Jokisaari <amjokisaari@users.noreply.github.com>
 John Peterson <jw.peterson@inl.gov>
+John Peterson <jwpeterson@gmail.com>
 Andrew Slaughter <andrew.slaughter@inl.gov>
 Jason Miller <jason.miller@inl.gov>
 Cody Permann <cody.permann@inl.gov>

--- a/tests/energy_auxkernels_test/AuxCalphadElasticity.i
+++ b/tests/energy_auxkernels_test/AuxCalphadElasticity.i
@@ -104,8 +104,7 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
+    displacements = 'disp_x disp_y'
   [../]
 
   [./dcdt]

--- a/tests/energy_auxkernels_test/AuxElasticEnergy.i
+++ b/tests/energy_auxkernels_test/AuxElasticEnergy.i
@@ -58,8 +58,7 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
+    displacements = 'disp_x disp_y'
   [../]
 []
 

--- a/tests/linear_elasticity/ACTransformElasticDF_test.i
+++ b/tests/linear_elasticity/ACTransformElasticDF_test.i
@@ -50,8 +50,7 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
+    displacements = 'disp_x disp_y'
   [../]
 
   [./dn1dt]

--- a/tests/linear_elasticity/Linear_Single_Xstal_Matl_test.i
+++ b/tests/linear_elasticity/Linear_Single_Xstal_Matl_test.i
@@ -48,8 +48,7 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
+    displacements = 'disp_x disp_y'
   [../]
   [./diff]
     type = Diffusion

--- a/tests/nucleation_auxkernels_test/AuxChemElastic.i
+++ b/tests/nucleation_auxkernels_test/AuxChemElastic.i
@@ -72,8 +72,7 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
+    displacements = 'disp_x disp_y'
   [../]
 
   [./CH]

--- a/tests/nucleation_auxkernels_test/AuxDeltaGStar_AuxChemElastic.i
+++ b/tests/nucleation_auxkernels_test/AuxDeltaGStar_AuxChemElastic.i
@@ -65,8 +65,7 @@
 
 [Kernels]
   [./TensorMechanics]
-    disp_x = disp_x
-    disp_y = disp_y
+    displacements = 'disp_x disp_y'
   [../]
 
   [./CH]


### PR DESCRIPTION
The TensorMechanics action now requires a displacements vector.

Refs idaholab/moose#6829.
